### PR TITLE
Fix: Add missing types.ts and transaction-builders.ts required for build

### DIFF
--- a/src/lib/tx/transaction-builders.ts
+++ b/src/lib/tx/transaction-builders.ts
@@ -1,0 +1,163 @@
+import { Transaction } from '@mysten/sui/transactions';
+import { KioskTransaction } from '@mysten/kiosk';
+import type { PavilionTxConfig, PavilionTxParams, ExistingKioskParams, SetSceneConfigParams } from './types';
+
+/**
+ * Fetch creation fee from PlatformConfig on-chain
+ */
+async function fetchCreationFee(suiClient: any, platformConfigId: string, packageId: string): Promise<string> {
+  try {
+    // Call the view function to get creation fee
+    const result = await suiClient.devInspectTransactionBlock({
+      transactionBlock: (() => {
+        const tx = new Transaction();
+        tx.moveCall({
+          target: `${packageId}::platform::get_creation_fee`,
+          arguments: [tx.object(platformConfigId)],
+        });
+        return tx;
+      })(),
+      sender: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    });
+
+    // Extract the fee from the result
+    if (result.results && result.results[0] && result.results[0].returnValues) {
+      const returnValue = result.results[0].returnValues[0];
+      if (returnValue && returnValue[0]) {
+        // Parse u64 from bytes
+        const bytes = returnValue[0];
+        const view = new DataView(new Uint8Array(bytes).buffer);
+        return view.getBigUint64(0, true).toString();
+      }
+    }
+    
+    // Fallback to default fee if query fails
+    return '1000000000'; // 1 SUI
+  } catch (error) {
+    console.error('Failed to fetch creation fee from chain:', error);
+    return '1000000000'; // 1 SUI fallback
+  }
+}
+
+/**
+ * Build a transaction to initialize a pavilion on an existing kiosk
+ */
+async function buildPavilionTxInternal(config: PavilionTxConfig): Promise<Transaction> {
+  const { kioskClient, packageId, pavilionName, ownerAddress, suiClient } = config;
+
+  // Fetch creation fee from chain
+  const creationFeeStr = await fetchCreationFee(suiClient, config.platformConfigId, packageId);
+  const feeAmount = parseInt(creationFeeStr, 10);
+
+  const tx = new Transaction();
+  let kioskTx: KioskTransaction;
+
+  // according to mode initialize kiosk
+  if (config.mode === 'create' || config.mode === 'auto') {
+    kioskTx = new KioskTransaction({ kioskClient, transaction: tx });
+    kioskTx.create();
+  } else {
+    // For existing kiosk, we need to get the full cap object
+    const { kioskOwnerCaps } = await kioskClient.getOwnedKiosks({ address: ownerAddress });
+    const targetCap = kioskOwnerCaps?.find(cap => cap.kioskId === config.kioskId);
+    
+    if (!targetCap) {
+      throw new Error(`Kiosk cap not found for kiosk ${config.kioskId}`);
+    }
+    
+    // Initialize KioskTransaction with the full cap object
+    kioskTx = new KioskTransaction({ 
+      kioskClient, 
+      transaction: tx, 
+      cap: targetCap 
+    });
+  }
+
+  // common initialize_pavilion call with payment
+  const { platformConfigId, platformRecipient } = config;
+  
+  // Split payment coin for the creation fee
+  const [paymentCoin] = tx.splitCoins(tx.gas, [tx.pure.u64(feeAmount)]);
+  
+  tx.moveCall({
+    target: `${packageId}::pavilion::initialize_pavilion`,
+    arguments: [
+      kioskTx.getKiosk(),
+      kioskTx.getKioskCap(),
+      tx.pure.string(pavilionName),
+      tx.object(platformConfigId),
+      paymentCoin,
+      tx.pure.address(platformRecipient),
+    ],
+  });
+
+  // only need to share and transfer cap when creating new kiosk
+  if (config.mode === 'create' || config.mode === 'auto') {
+    kioskTx.shareAndTransferCap(ownerAddress);
+  }
+
+  kioskTx.finalize();
+  return tx;
+}
+
+export async function buildCreatePavilionTx(params: PavilionTxParams): Promise<Transaction> {
+  return buildPavilionTxInternal({
+    mode: 'create',
+    ...params,
+  });
+}
+
+export async function buildInitializePavilionWithExistingKioskTx(params: ExistingKioskParams): Promise<Transaction> {
+  return buildPavilionTxInternal({
+    mode: 'existing',
+    ...params,
+  });
+}
+
+/**
+ * Build a transaction to initialize a pavilion automatically
+ * If user has existing kiosk, use it; otherwise create a new one
+ * The kiosk cap will be transferred back to the owner in both cases
+ */
+export async function buildAutoPavilionTx(params: PavilionTxParams): Promise<Transaction> {
+  const { kioskClient, ownerAddress } = params;
+
+  try {
+    // Try to get existing kiosk for the user
+    const { kioskOwnerCaps } = await kioskClient.getOwnedKiosks({ address: ownerAddress });
+
+    if (kioskOwnerCaps && kioskOwnerCaps.length > 0) {
+      // User has existing kiosk, use it
+      const existingKioskCap = kioskOwnerCaps[0];
+      return buildPavilionTxInternal({
+        mode: 'existing',
+        ...params,
+        kioskId: existingKioskCap.kioskId,
+        kioskOwnerCapId: existingKioskCap.objectId,
+      });
+    }
+  } catch (error) {
+    // If there's an error getting kiosks (e.g., no kiosks), continue to create new one
+    console.log('No existing kiosk found, creating new one:', error);
+  }
+
+  // No existing kiosk found, create a new one
+  return buildPavilionTxInternal({
+    mode: 'auto',
+    ...params,
+  });
+}
+
+export function setSceneConfigTx(params: SetSceneConfigParams): Transaction {
+  const { kioskClient, packageId, kioskId, kioskOwnerCapId, json } = params;
+  const tx = new Transaction();
+  const kioskTx = new KioskTransaction({ kioskClient, transaction: tx });
+  kioskTx.setKiosk(tx.object(kioskId));
+  kioskTx.setKioskCap(tx.object(kioskOwnerCapId));
+  tx.moveCall({
+    target: `${packageId}::pavilion::set_scene_config`,
+    arguments: [kioskTx.getKiosk(), kioskTx.getKioskCap(), tx.pure.string(json)],
+  });
+  kioskTx.finalize();
+  return tx;
+}

--- a/src/lib/tx/types.ts
+++ b/src/lib/tx/types.ts
@@ -1,0 +1,124 @@
+import type { KioskClient } from '@mysten/kiosk';
+import type { Transaction } from '@mysten/sui/transactions';
+
+export type PavilionTxConfig =
+  | {
+      mode: 'create';
+      kioskClient: KioskClient;
+      packageId: string;
+      pavilionName: string;
+      ownerAddress: string;
+      platformConfigId: string;
+      platformRecipient: string;
+      suiClient: any;
+    }
+  | {
+      mode: 'existing';
+      kioskClient: KioskClient;
+      packageId: string;
+      pavilionName: string;
+      ownerAddress: string;
+      kioskId: string;
+      kioskOwnerCapId: string;
+      platformConfigId: string;
+      platformRecipient: string;
+      suiClient: any;
+    }
+  | {
+      mode: 'auto';
+      kioskClient: KioskClient;
+      packageId: string;
+      pavilionName: string;
+      ownerAddress: string;
+      platformConfigId: string;
+      platformRecipient: string;
+      suiClient: any;
+    };
+
+export interface PavilionTxParams {
+  kioskClient: KioskClient;
+  packageId: string;
+  pavilionName: string;
+  ownerAddress: string;
+  platformConfigId: string;
+  platformRecipient: string;
+  suiClient: any;
+}
+
+export interface ExistingKioskParams extends PavilionTxParams {
+  kioskId: string;
+  kioskOwnerCapId: string;
+}
+
+export interface KioskIdsResult {
+  kioskId?: string;
+  kioskOwnerCapId?: string;
+}
+
+export interface FetchKioskContentsParams {
+  kioskClient: KioskClient;
+  kioskId: string;
+  retries?: number;
+  delayMs?: number;
+}
+
+export interface ResolveKioskOwnerCapParams {
+  kioskClient: KioskClient;
+  ownerAddress: string;
+  kioskId: string;
+}
+
+export interface FetchKioskIdsParams {
+  kioskClient: KioskClient;
+  digest?: string;
+  result?: any;
+}
+
+export interface SceneConfigParams {
+  suiClient: any;
+  packageId: string;
+  kioskId: string;
+}
+
+export interface SetSceneConfigParams {
+  kioskClient: KioskClient;
+  packageId: string;
+  kioskId: string;
+  kioskOwnerCapId: string;
+  json: string;
+}
+
+export interface DebugDynamicFieldsParams {
+  suiClient: any;
+  kioskId: string;
+}
+
+export interface PurchaseTransactionParams {
+  kioskClient: KioskClient;
+  itemId: string;
+  itemType: string;
+  price: string;
+  sellerKiosk: string;
+  buyerAddress: string;
+  targetKioskId?: string;  // Optional: specific kiosk to place purchased item
+  targetKioskCapId?: string;  // Optional: kiosk owner cap for target kiosk
+}
+
+export interface PurchaseTransactionResult {
+  transaction: Transaction;
+  isNewKiosk: boolean;
+  buyerKioskId?: string;
+}
+
+export interface WithdrawProfitsParams {
+  kioskClient: KioskClient;
+  kioskId: string;
+  kioskOwnerCapId: string;
+  ownerAddress: string;
+  amount?: string; // Amount in MIST to withdraw, if not specified withdraws all profits
+}
+
+export interface WithdrawProfitsResult {
+  transaction: Transaction;
+  withdrawnAmount?: string;
+}


### PR DESCRIPTION
## 問題
Main 分支缺少 `src/lib/tx/types.ts` 和 `src/lib/tx/transaction-builders.ts`，導致編譯失敗。

## 修復
從正常運作的分支恢復這兩個必要的類型定義文件。